### PR TITLE
Fix include path that was missed after core-util rename

### DIFF
--- a/module.json
+++ b/module.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "dlmalloc": "~0.0.0",
-    "core-util": ">=0.1.0"
+    "core-util": "~0.2.0"
   },
   "scripts": {
     "testReporter": [

--- a/test/unit/main.cpp
+++ b/test/unit/main.cpp
@@ -17,7 +17,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "mbed/test_env.h"
-#include "mbed-util/sbrk.h"
+#include "core-util/sbrk.h"
 #include "mbed-alloc/ualloc.h"
 
 


### PR DESCRIPTION
Ualloc test did not compile due to rename of mbed-util to core-util.
@0xc0170 @bremoran 