### PR TITLE
[devel_transport] Port test to async model

### DIFF
--- a/module.json
+++ b/module.json
@@ -21,9 +21,11 @@
       "type": "Apache-2.0"
     }
   ],
-  "dependencies": {
+  "testDependencies": {
     "dlmalloc": "^1.0.0",
-    "core-util": "^1.0.0"
+    "core-util": "^1.0.0",
+    "unity": "^2.0.0",
+    "greentea-client": "^0.1.4"
   },
   "scripts": {
     "testReporter": [

--- a/module.json
+++ b/module.json
@@ -21,11 +21,13 @@
       "type": "Apache-2.0"
     }
   ],
-  "testDependencies": {
+  "dependencies": {
     "dlmalloc": "^1.0.0",
-    "core-util": "^1.0.0",
+    "core-util": "^1.0.0"
+  },
+  "testDependencies": {
     "unity": "^2.0.0",
-    "greentea-client": "^0.1.4"
+    "greentea-client": "~0.1.4"
   },
   "scripts": {
     "testReporter": [

--- a/test/unit/main.cpp
+++ b/test/unit/main.cpp
@@ -16,10 +16,15 @@
  */
 #include <stddef.h>
 #include <stdint.h>
-#include "mbed-drivers/test_env.h"
+#include <stdlib.h>
+#include <string.h>
+#include "greentea-client/test_env.h"
+#include "unity/unity.h"
+#include "utest/utest.h"
 #include "core-util/sbrk.h"
 #include "ualloc/ualloc.h"
 
+using namespace utest::v1;
 
 extern void * volatile mbed_sbrk_ptr;
 extern void * volatile mbed_krbs_ptr;
@@ -27,11 +32,7 @@ extern volatile uintptr_t mbed_sbrk_diff;
 
 #define TEST_SIZE_0 0x20
 
-void app_start(int, char**) {
-    MBED_HOSTTEST_TIMEOUT(10);
-    MBED_HOSTTEST_SELECT(default);
-    MBED_HOSTTEST_DESCRIPTION(ualloc zone test);
-    MBED_HOSTTEST_START("UALLOC_ZONE");
+void test_ualloc_zone() {
     const char * current_test = "none";
     UAllocTraits_t traits;
 
@@ -218,5 +219,24 @@ void app_start(int, char**) {
         printf("First failing test: %s\r\n", current_test);
     }
 
-    MBED_HOSTTEST_RESULT(tests_pass);
+    TEST_ASSERT_TRUE(tests_pass);
+}
+
+status_t greentea_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(10, "default_auto");
+
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+/* Tests for malloc provided by ualloc module */
+Case cases[] =
+{
+    Case("Ualloc test", test_ualloc_zone),
+};
+
+Specification specification(greentea_setup, cases, greentea_test_teardown_handler);
+
+void app_start(int, char**) {
+    Harness::run(specification);
 }


### PR DESCRIPTION
Test results from ```$mbedgt -VS --report-junit JUnit.xml```:
```
mbedgt: test suite report:
+---------------+---------------+------------------+--------+--------------------+-------------+
| target        | platform_name | test suite       | result | elapsed_time (sec) | copy_method |
+---------------+---------------+------------------+--------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | ualloc-test-unit | OK     | 10.65              | shell       |
+---------------+---------------+------------------+--------+--------------------+-------------+
mbedgt: test suite results: 1 OK
mbedgt: test case report:
+---------------+---------------+------------------+-------------+--------+--------+--------+--------------------+
| target        | platform_name | test suite       | test case   | passed | failed | result | elapsed_time (sec) |
+---------------+---------------+------------------+-------------+--------+--------+--------+--------------------+
| frdm-k64f-gcc | K64F          | ualloc-test-unit | Ualloc test | 1      | 0      | OK     | 0.04               |
+---------------+---------------+------------------+-------------+--------+--------+--------+--------------------+
mbedgt: test case results: 1 OK
mbedgt: completed in 12.01 sec
```
```
$yt ls
ualloc 1.0.3
|_ dlmalloc 1.0.0 (test dependency)
|_ core-util 1.3.0 (test dependency)
| |_ cmsis-core 1.1.2 yotta_modules\cmsis-core
| | \_ cmsis-core-freescale 1.0.0 yotta_modules\cmsis-core-freescale
| |   \_ cmsis-core-k64f 1.0.0 yotta_modules\cmsis-core-k64f
| \_ mbed-drivers 0.12.1 yotta_modules\mbed-drivers
|   |_ mbed-hal 1.2.2 yotta_modules\mbed-hal
|   | \_ mbed-hal-freescale 1.0.0 yotta_modules\mbed-hal-freescale
|   |   \_ mbed-hal-ksdk-mcu 1.0.8 yotta_modules\mbed-hal-ksdk-mcu
|   |     |_ uvisor-lib 1.0.12 yotta_modules\uvisor-lib
|   |     \_ mbed-hal-k64f 1.1.0 yotta_modules\mbed-hal-k64f
|   |       \_ mbed-hal-frdm-k64f 1.0.2 yotta_modules\mbed-hal-frdm-k64f
|   |_ minar 1.0.4 yotta_modules\minar
|   | \_ minar-platform 1.0.0 yotta_modules\minar-platform
|   |   \_ minar-platform-mbed 1.1.2 yotta_modules\minar-platform-mbed
|   \_ compiler-polyfill 1.2.1 yotta_modules\compiler-polyfill
|_ unity 2.1.0 (test dependency)
| \_ utest 1.9.1 yotta_modules\utest -> C:\Users\stefan.gutmann@arm.com\Documents\GitHub\Demo\utest
\_ greentea-client 0.1.4 (test dependency)
```